### PR TITLE
Improve createSpriteMap return type

### DIFF
--- a/packages/createSpriteMap.ts
+++ b/packages/createSpriteMap.ts
@@ -16,7 +16,7 @@
  */
 
 import { renderer } from '@lightningjs/solid';
-import { type TextureRef } from '@lightningjs/renderer';
+import { type SpecificTextureRef } from '@lightningjs/renderer';
 
 export interface SpriteDef {
   name: string;
@@ -31,7 +31,7 @@ export function createSpriteMap(src: string, subTextures: SpriteDef[]) {
     src,
   });
 
-  return subTextures.reduce<Record<string, TextureRef>>((acc, t) => {
+  return subTextures.reduce<Record<string, SpecificTextureRef<"SubTexture">>>((acc, t) => {
     const { x, y, width, height } = t;
     acc[t.name] = renderer.createTexture('SubTexture', {
       texture: spriteMapTexture,


### PR DESCRIPTION
This makes the return type for createSpriteMap more specific which improves the typing experience in the solid-demo-app.