### PR TITLE
fix: removed unnecessary key map entrys

### DIFF
--- a/packages/useFocusManager.ts
+++ b/packages/useFocusManager.ts
@@ -110,14 +110,6 @@ const keyMapEntries: Record<string | number, string> = {
   ' ': 'Space',
   Backspace: 'Back',
   Escape: 'Escape',
-  37: 'Left',
-  39: 'Right',
-  38: 'Up',
-  40: 'Down',
-  13: 'Enter',
-  32: 'Space',
-  8: 'Back',
-  27: 'Escape',
 };
 
 const [focusPath, setFocusPath] = createSignal<ElementNode[]>([]);


### PR DESCRIPTION
Shouldn't be needed as keyCodes are standard and resolve to existing entries in keyMap - introduces unintended back intentions when key value "8" is pressed on keyboard/ STB remote